### PR TITLE
fix Error - module GitbeholderWeb is not loaded and could not be found

### DIFF
--- a/lib/git_beholder_web/controllers/git_log_controller.ex
+++ b/lib/git_beholder_web/controllers/git_log_controller.ex
@@ -1,5 +1,5 @@
 defmodule GitBeholderWeb.GitLogController do
-  use GitbeholderWeb, :controller
+  use GitBeholderWeb, :controller
   alias GitBeholder.GitLog
 
   def index(conn, %{"repo_path" => path} = params) do


### PR DESCRIPTION
The error is occured when I have cloned the source and run using command 'mix phx.server'

I have fixed the error changing use clause.