### PR TITLE
Scope Git operations to a validated repository (ADR 007)

### DIFF
--- a/lib/git_beholder_web/controllers/git_commit_controller.ex
+++ b/lib/git_beholder_web/controllers/git_commit_controller.ex
@@ -2,8 +2,10 @@ defmodule GitBeholderWeb.GitCommitController do
   use GitBeholderWeb, :controller
   alias GitBeholder.GitCommit
 
-  def create(conn, %{"repo_path" => repo_path, "file_path" => file_path, "message" => message}) do
-    case GitCommit.commit_file(repo_path, file_path, message) do
+  def create(conn, %{"file_path" => file_path} = params) do
+    message = Map.get(params, "message", "Commit via Gitbehodler API")
+
+    case GitCommit.commit_file(conn.assigns.repository.path, file_path, message) do
       {:ok, output} ->
         json(conn, %{status: "ok", message: output})
 
@@ -12,9 +14,5 @@ defmodule GitBeholderWeb.GitCommitController do
         |> put_status(:bad_request)
         |> json(%{status: "error", message: error_msg})
     end
-  end
-
-  def create(conn, %{"repo_path" => repo_path, "file_path" => file_path}) do
-    create(conn, %{"repo_path" => repo_path, "file_path" => file_path, "message" => "Commit via Gitbehodler API"})
   end
 end

--- a/lib/git_beholder_web/controllers/git_log_controller.ex
+++ b/lib/git_beholder_web/controllers/git_log_controller.ex
@@ -2,10 +2,10 @@ defmodule GitBeholderWeb.GitLogController do
   use GitBeholderWeb, :controller
   alias GitBeholder.GitLog
 
-  def index(conn, %{"repo_path" => path} = params) do
+  def index(conn, params) do
     limit = Map.get(params, "limit", "10") |> String.to_integer()
 
-    case GitLog.list_commits(path, limit) do
+    case GitLog.list_commits(conn.assigns.repository.path, limit) do
       {:ok, commits} ->
         json(conn, commits)
 

--- a/lib/git_beholder_web/controllers/git_status_controller.ex
+++ b/lib/git_beholder_web/controllers/git_status_controller.ex
@@ -2,13 +2,13 @@ defmodule GitBeholderWeb.GitStatusController do
   use GitBeholderWeb, :controller
   alias GitBeholder.GitStatus
 
-  def status(conn, %{"path" => path}) do
-    case GitStatus.git_status(path) do
+  def status(conn, _params) do
+    case GitStatus.git_status(conn.assigns.repository.path) do
       {:ok, output} ->
         json(conn, %{status: "ok", output: output})
 
-        {:error, error_output} ->
-          json(conn, %{status: "error", output: error_output})
+      {:error, error_output} ->
+        json(conn, %{status: "error", output: error_output})
     end
   end
 end

--- a/lib/git_beholder_web/plugs/fetch_repository.ex
+++ b/lib/git_beholder_web/plugs/fetch_repository.ex
@@ -1,0 +1,39 @@
+defmodule GitBeholderWeb.Plugs.FetchRepository do
+  @moduledoc """
+  Resolves `workspace_id`/`repository_id` path params into a validated
+  `GitBeholder.Repositories.Repository`, assigned as `conn.assigns.repository`.
+
+  Halts the connection with 404 (unknown repository / unavailable path) or
+  400 (malformed ids) before any controller action runs.
+  """
+
+  import Plug.Conn
+  import Phoenix.Controller, only: [json: 2]
+
+  alias GitBeholder.Repositories
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    %{"workspace_id" => workspace_id, "repository_id" => repository_id} = conn.params
+
+    with {workspace_id, ""} <- Integer.parse(workspace_id),
+         {repository_id, ""} <- Integer.parse(repository_id),
+         {:ok, repository} <- Repositories.fetch_repository(workspace_id, repository_id) do
+      assign(conn, :repository, repository)
+    else
+      {:error, reason} ->
+        halt_with_error(conn, :not_found, to_string(reason))
+
+      _ ->
+        halt_with_error(conn, :bad_request, "invalid workspace or repository id")
+    end
+  end
+
+  defp halt_with_error(conn, status, message) do
+    conn
+    |> put_status(status)
+    |> json(%{error: message})
+    |> halt()
+  end
+end

--- a/lib/git_beholder_web/router.ex
+++ b/lib/git_beholder_web/router.ex
@@ -5,13 +5,22 @@ defmodule GitBeholderWeb.Router do
     plug :accepts, ["json"]
   end
 
+  pipeline :repository do
+    plug GitBeholderWeb.Plugs.FetchRepository
+  end
+
   scope "/api", GitBeholderWeb do
     pipe_through :api
 
-    get  "/git/status", GitStatusController, :status
-    post "/git/commit", GitCommitController, :create
-    get  "/git/log", GitLogController, :index
-    get  "/git/repositories", GitRepositoryController, :index
+    get "/git/repositories", GitRepositoryController, :index
+  end
+
+  scope "/api/v1/workspaces/:workspace_id/repositories/:repository_id", GitBeholderWeb do
+    pipe_through [:api, :repository]
+
+    get "/status", GitStatusController, :status
+    post "/commit", GitCommitController, :create
+    get "/log", GitLogController, :index
   end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development

--- a/test/git_beholder_web/controllers/git_commit_controller_test.exs
+++ b/test/git_beholder_web/controllers/git_commit_controller_test.exs
@@ -1,0 +1,55 @@
+defmodule GitBeholderWeb.GitCommitControllerTest do
+  use GitBeholderWeb.ConnCase, async: true
+
+  alias GitBeholder.Repositories
+
+  setup %{conn: conn} do
+    repo_path =
+      Path.join(System.tmp_dir!(), "git_beholder_commit_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(repo_path)
+    {_, 0} = System.cmd("git", ["init"], cd: repo_path)
+    {_, 0} = System.cmd("git", ["config", "user.email", "test@example.com"], cd: repo_path)
+    {_, 0} = System.cmd("git", ["config", "user.name", "Test User"], cd: repo_path)
+    File.write!(Path.join(repo_path, "file.txt"), "hello")
+
+    on_exit(fn -> File.rm_rf!(repo_path) end)
+
+    {:ok, workspace} = Repositories.create_workspace(%{name: "Engineering"})
+
+    {:ok, repository} =
+      Repositories.create_repository(%{
+        name: "scratch_repo",
+        path: repo_path,
+        workspace_id: workspace.id
+      })
+
+    %{conn: conn, workspace: workspace, repository: repository}
+  end
+
+  test "POST .../commit commits the given file", %{
+    conn: conn,
+    workspace: workspace,
+    repository: repository
+  } do
+    conn =
+      post(
+        conn,
+        "/api/v1/workspaces/#{workspace.id}/repositories/#{repository.id}/commit",
+        %{"file_path" => "file.txt", "message" => "Initial commit"}
+      )
+
+    assert %{"status" => "ok"} = json_response(conn, 200)
+  end
+
+  test "returns 404 for an unknown repository", %{conn: conn, workspace: workspace} do
+    conn =
+      post(
+        conn,
+        "/api/v1/workspaces/#{workspace.id}/repositories/999999/commit",
+        %{"file_path" => "file.txt"}
+      )
+
+    assert json_response(conn, 404)
+  end
+end

--- a/test/git_beholder_web/controllers/git_log_controller_test.exs
+++ b/test/git_beholder_web/controllers/git_log_controller_test.exs
@@ -1,0 +1,39 @@
+defmodule GitBeholderWeb.GitLogControllerTest do
+  use GitBeholderWeb.ConnCase, async: true
+
+  alias GitBeholder.Repositories
+
+  setup %{conn: conn} do
+    {:ok, workspace} = Repositories.create_workspace(%{name: "Engineering"})
+
+    {:ok, repository} =
+      Repositories.create_repository(%{
+        name: "git_beholder",
+        path: File.cwd!(),
+        workspace_id: workspace.id
+      })
+
+    %{conn: conn, workspace: workspace, repository: repository}
+  end
+
+  test "GET .../log returns recent commits", %{
+    conn: conn,
+    workspace: workspace,
+    repository: repository
+  } do
+    conn =
+      get(
+        conn,
+        "/api/v1/workspaces/#{workspace.id}/repositories/#{repository.id}/log?limit=3"
+      )
+
+    assert [%{"hash" => _, "author" => _, "date" => _, "message" => _} | _] =
+             json_response(conn, 200)
+  end
+
+  test "returns 404 for an unknown repository", %{conn: conn, workspace: workspace} do
+    conn = get(conn, "/api/v1/workspaces/#{workspace.id}/repositories/999999/log")
+
+    assert json_response(conn, 404)
+  end
+end

--- a/test/git_beholder_web/controllers/git_status_controller_test.exs
+++ b/test/git_beholder_web/controllers/git_status_controller_test.exs
@@ -1,0 +1,35 @@
+defmodule GitBeholderWeb.GitStatusControllerTest do
+  use GitBeholderWeb.ConnCase, async: true
+
+  alias GitBeholder.Repositories
+
+  setup %{conn: conn} do
+    {:ok, workspace} = Repositories.create_workspace(%{name: "Engineering"})
+
+    {:ok, repository} =
+      Repositories.create_repository(%{
+        name: "git_beholder",
+        path: File.cwd!(),
+        workspace_id: workspace.id
+      })
+
+    %{conn: conn, workspace: workspace, repository: repository}
+  end
+
+  test "GET .../status returns the repository status", %{
+    conn: conn,
+    workspace: workspace,
+    repository: repository
+  } do
+    conn = get(conn, "/api/v1/workspaces/#{workspace.id}/repositories/#{repository.id}/status")
+
+    assert %{"status" => "ok", "output" => output} = json_response(conn, 200)
+    assert is_binary(output)
+  end
+
+  test "returns 404 for an unknown repository", %{conn: conn, workspace: workspace} do
+    conn = get(conn, "/api/v1/workspaces/#{workspace.id}/repositories/999999/status")
+
+    assert json_response(conn, 404)
+  end
+end

--- a/test/git_beholder_web/plugs/fetch_repository_test.exs
+++ b/test/git_beholder_web/plugs/fetch_repository_test.exs
@@ -1,0 +1,78 @@
+defmodule GitBeholderWeb.Plugs.FetchRepositoryTest do
+  use GitBeholder.DataCase, async: true
+
+  import Plug.Test
+
+  alias GitBeholder.Repositories
+  alias GitBeholderWeb.Plugs.FetchRepository
+
+  setup do
+    {:ok, workspace} = Repositories.create_workspace(%{name: "Engineering"})
+
+    {:ok, repository} =
+      Repositories.create_repository(%{
+        name: "git_beholder",
+        path: File.cwd!(),
+        workspace_id: workspace.id
+      })
+
+    %{workspace: workspace, repository: repository}
+  end
+
+  defp conn_with_params(workspace_id, repository_id) do
+    :get
+    |> conn("/api/v1/workspaces/#{workspace_id}/repositories/#{repository_id}/status")
+    |> Map.put(:params, %{
+      "workspace_id" => to_string(workspace_id),
+      "repository_id" => to_string(repository_id)
+    })
+  end
+
+  test "assigns the resolved repository when found", %{
+    workspace: workspace,
+    repository: repository
+  } do
+    conn =
+      workspace.id
+      |> conn_with_params(repository.id)
+      |> FetchRepository.call([])
+
+    refute conn.halted
+    assert conn.assigns.repository.id == repository.id
+  end
+
+  test "halts with 404 for an unknown repository", %{workspace: workspace} do
+    conn =
+      workspace.id
+      |> conn_with_params(999_999)
+      |> FetchRepository.call([])
+
+    assert conn.halted
+    assert conn.status == 404
+  end
+
+  test "halts with 404 when the repository belongs to a different workspace", %{
+    repository: repository
+  } do
+    {:ok, other_workspace} = Repositories.create_workspace(%{name: "Sales"})
+
+    conn =
+      other_workspace.id
+      |> conn_with_params(repository.id)
+      |> FetchRepository.call([])
+
+    assert conn.halted
+    assert conn.status == 404
+  end
+
+  test "halts with 400 for a non-numeric id" do
+    conn =
+      :get
+      |> conn("/api/v1/workspaces/abc/repositories/def/status")
+      |> Map.put(:params, %{"workspace_id" => "abc", "repository_id" => "def"})
+      |> FetchRepository.call([])
+
+    assert conn.halted
+    assert conn.status == 400
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -31,7 +31,8 @@ defmodule GitBeholderWeb.ConnCase do
     end
   end
 
-  setup _tags do
+  setup tags do
+    GitBeholder.DataCase.setup_sandbox(tags)
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
 end


### PR DESCRIPTION
## Summary
- Adds `GitBeholderWeb.Plugs.FetchRepository`, resolving `workspace_id`/`repository_id` path params to a validated `GitBeholder.Repositories.Repository` before any controller runs, halting with 404 (unknown/unavailable) or 400 (malformed ids)
- Moves `status`/`commit`/`log` under `/api/v1/workspaces/:workspace_id/repositories/:repository_id/...`, piped through the new plug
- Controllers now read the resolved path from `conn.assigns.repository` instead of trusting a client-supplied `path`/`repo_path` param

Breaking change: `/api/git/status`, `/api/git/commit`, and `/api/git/log` are removed in favor of the workspace/repository-scoped `v1` routes.

Implements the routing/security boundary decided in ADR 007 (built on the Workspace/Folder/Repository model from ADR 005 and the Ecto persistence layer from ADR 006).

## Test plan
- [x] `mix test` - 39 tests, 0 failures
- [x] Plug tested directly (found/not-found/cross-workspace/malformed id)
- [x] Controller tests for the new nested routes (status, log against a real repo; commit against a disposable temp repo, not the project's own)