### PR TITLE
Add Workspace/Folder/Repository CRUD endpoints

### DIFF
--- a/lib/git_beholder/repositories.ex
+++ b/lib/git_beholder/repositories.ex
@@ -10,6 +10,13 @@ defmodule GitBeholder.Repositories do
   alias GitBeholder.Repositories.{Workspace, Folder, Repository}
 
   @doc """
+  Lists all Workspaces.
+  """
+  def list_workspaces do
+    Repo.all(Workspace)
+  end
+
+  @doc """
   Creates a Workspace.
   """
   def create_workspace(attrs) do

--- a/lib/git_beholder_web/controllers/changeset_json.ex
+++ b/lib/git_beholder_web/controllers/changeset_json.ex
@@ -1,0 +1,12 @@
+defmodule GitBeholderWeb.ChangesetJSON do
+  @doc """
+  Traverses changeset errors into a plain map of field => messages.
+  """
+  def errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+      end)
+    end)
+  end
+end

--- a/lib/git_beholder_web/controllers/folder_controller.ex
+++ b/lib/git_beholder_web/controllers/folder_controller.ex
@@ -1,0 +1,28 @@
+defmodule GitBeholderWeb.FolderController do
+  use GitBeholderWeb, :controller
+
+  alias GitBeholder.Repositories
+
+  def create(conn, params) do
+    case Repositories.create_folder(params) do
+      {:ok, folder} ->
+        conn
+        |> put_status(:created)
+        |> json(folder_json(folder))
+
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{errors: GitBeholderWeb.ChangesetJSON.errors(changeset)})
+    end
+  end
+
+  defp folder_json(folder) do
+    %{
+      id: folder.id,
+      name: folder.name,
+      workspace_id: folder.workspace_id,
+      parent_folder_id: folder.parent_folder_id
+    }
+  end
+end

--- a/lib/git_beholder_web/controllers/repository_controller.ex
+++ b/lib/git_beholder_web/controllers/repository_controller.ex
@@ -1,0 +1,29 @@
+defmodule GitBeholderWeb.RepositoryController do
+  use GitBeholderWeb, :controller
+
+  alias GitBeholder.Repositories
+
+  def create(conn, params) do
+    case Repositories.create_repository(params) do
+      {:ok, repository} ->
+        conn
+        |> put_status(:created)
+        |> json(repository_json(repository))
+
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{errors: GitBeholderWeb.ChangesetJSON.errors(changeset)})
+    end
+  end
+
+  defp repository_json(repository) do
+    %{
+      id: repository.id,
+      name: repository.name,
+      path: repository.path,
+      workspace_id: repository.workspace_id,
+      folder_id: repository.folder_id
+    }
+  end
+end

--- a/lib/git_beholder_web/controllers/workspace_controller.ex
+++ b/lib/git_beholder_web/controllers/workspace_controller.ex
@@ -1,0 +1,28 @@
+defmodule GitBeholderWeb.WorkspaceController do
+  use GitBeholderWeb, :controller
+
+  alias GitBeholder.Repositories
+
+  def index(conn, _params) do
+    workspaces = Enum.map(Repositories.list_workspaces(), &workspace_json/1)
+    json(conn, %{workspaces: workspaces})
+  end
+
+  def create(conn, params) do
+    case Repositories.create_workspace(params) do
+      {:ok, workspace} ->
+        conn
+        |> put_status(:created)
+        |> json(workspace_json(workspace))
+
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{errors: GitBeholderWeb.ChangesetJSON.errors(changeset)})
+    end
+  end
+
+  defp workspace_json(workspace) do
+    %{id: workspace.id, name: workspace.name}
+  end
+end

--- a/lib/git_beholder_web/router.ex
+++ b/lib/git_beholder_web/router.ex
@@ -15,6 +15,16 @@ defmodule GitBeholderWeb.Router do
     get "/git/repositories", GitRepositoryController, :index
   end
 
+  scope "/api/v1", GitBeholderWeb do
+    pipe_through :api
+
+    get  "/workspaces", WorkspaceController, :index
+    post "/workspaces", WorkspaceController, :create
+
+    post "/workspaces/:workspace_id/folders", FolderController, :create
+    post "/workspaces/:workspace_id/repositories", RepositoryController, :create
+  end
+
   scope "/api/v1/workspaces/:workspace_id/repositories/:repository_id", GitBeholderWeb do
     pipe_through [:api, :repository]
 

--- a/test/git_beholder/repositories_test.exs
+++ b/test/git_beholder/repositories_test.exs
@@ -3,6 +3,18 @@ defmodule GitBeholder.RepositoriesTest do
 
   alias GitBeholder.Repositories
 
+  describe "list_workspaces/0" do
+    test "returns all workspaces" do
+      {:ok, workspace_a} = Repositories.create_workspace(%{name: "Engineering"})
+      {:ok, workspace_b} = Repositories.create_workspace(%{name: "Sales"})
+
+      ids = Repositories.list_workspaces() |> Enum.map(& &1.id)
+
+      assert workspace_a.id in ids
+      assert workspace_b.id in ids
+    end
+  end
+
   describe "create_workspace/1" do
     test "creates a workspace with a valid name" do
       assert {:ok, workspace} = Repositories.create_workspace(%{name: "Engineering"})

--- a/test/git_beholder_web/controllers/folder_controller_test.exs
+++ b/test/git_beholder_web/controllers/folder_controller_test.exs
@@ -1,0 +1,42 @@
+defmodule GitBeholderWeb.FolderControllerTest do
+  use GitBeholderWeb.ConnCase, async: true
+
+  alias GitBeholder.Repositories
+
+  setup do
+    {:ok, workspace} = Repositories.create_workspace(%{name: "Engineering"})
+    %{workspace: workspace}
+  end
+
+  describe "POST /api/v1/workspaces/:workspace_id/folders" do
+    test "creates a top-level folder", %{conn: conn, workspace: workspace} do
+      conn =
+        post(conn, "/api/v1/workspaces/#{workspace.id}/folders", %{"name" => "Backend"})
+
+      assert %{"id" => id, "name" => "Backend", "workspace_id" => workspace_id, "parent_folder_id" => nil} =
+               json_response(conn, 201)
+
+      assert is_integer(id)
+      assert workspace_id == workspace.id
+    end
+
+    test "creates a nested folder", %{conn: conn, workspace: workspace} do
+      {:ok, parent} = Repositories.create_folder(%{name: "Backend", workspace_id: workspace.id})
+
+      conn =
+        post(conn, "/api/v1/workspaces/#{workspace.id}/folders", %{
+          "name" => "Payments",
+          "parent_folder_id" => parent.id
+        })
+
+      assert %{"parent_folder_id" => parent_id} = json_response(conn, 201)
+      assert parent_id == parent.id
+    end
+
+    test "returns 422 without a name", %{conn: conn, workspace: workspace} do
+      conn = post(conn, "/api/v1/workspaces/#{workspace.id}/folders", %{})
+
+      assert %{"errors" => %{"name" => ["can't be blank"]}} = json_response(conn, 422)
+    end
+  end
+end

--- a/test/git_beholder_web/controllers/repository_controller_test.exs
+++ b/test/git_beholder_web/controllers/repository_controller_test.exs
@@ -1,0 +1,52 @@
+defmodule GitBeholderWeb.RepositoryControllerTest do
+  use GitBeholderWeb.ConnCase, async: true
+
+  alias GitBeholder.Repositories
+
+  setup do
+    {:ok, workspace} = Repositories.create_workspace(%{name: "Engineering"})
+    %{workspace: workspace}
+  end
+
+  describe "POST /api/v1/workspaces/:workspace_id/repositories" do
+    test "registers a repository at the workspace root", %{conn: conn, workspace: workspace} do
+      conn =
+        post(conn, "/api/v1/workspaces/#{workspace.id}/repositories", %{
+          "name" => "payment_service",
+          "path" => "/repos/payment_service"
+        })
+
+      assert %{
+               "id" => id,
+               "name" => "payment_service",
+               "path" => "/repos/payment_service",
+               "workspace_id" => workspace_id,
+               "folder_id" => nil
+             } = json_response(conn, 201)
+
+      assert is_integer(id)
+      assert workspace_id == workspace.id
+    end
+
+    test "registers a repository inside a folder", %{conn: conn, workspace: workspace} do
+      {:ok, folder} = Repositories.create_folder(%{name: "Backend", workspace_id: workspace.id})
+
+      conn =
+        post(conn, "/api/v1/workspaces/#{workspace.id}/repositories", %{
+          "name" => "payment_service",
+          "path" => "/repos/payment_service",
+          "folder_id" => folder.id
+        })
+
+      assert %{"folder_id" => folder_id} = json_response(conn, 201)
+      assert folder_id == folder.id
+    end
+
+    test "returns 422 without a path", %{conn: conn, workspace: workspace} do
+      conn =
+        post(conn, "/api/v1/workspaces/#{workspace.id}/repositories", %{"name" => "x"})
+
+      assert %{"errors" => %{"path" => ["can't be blank"]}} = json_response(conn, 422)
+    end
+  end
+end

--- a/test/git_beholder_web/controllers/workspace_controller_test.exs
+++ b/test/git_beholder_web/controllers/workspace_controller_test.exs
@@ -1,0 +1,31 @@
+defmodule GitBeholderWeb.WorkspaceControllerTest do
+  use GitBeholderWeb.ConnCase, async: true
+
+  alias GitBeholder.Repositories
+
+  describe "GET /api/v1/workspaces" do
+    test "lists all workspaces", %{conn: conn} do
+      {:ok, workspace} = Repositories.create_workspace(%{name: "Engineering"})
+
+      conn = get(conn, "/api/v1/workspaces")
+
+      assert %{"workspaces" => workspaces} = json_response(conn, 200)
+      assert %{"id" => workspace.id, "name" => "Engineering"} in workspaces
+    end
+  end
+
+  describe "POST /api/v1/workspaces" do
+    test "creates a workspace with a valid name", %{conn: conn} do
+      conn = post(conn, "/api/v1/workspaces", %{"name" => "Engineering"})
+
+      assert %{"id" => id, "name" => "Engineering"} = json_response(conn, 201)
+      assert is_integer(id)
+    end
+
+    test "returns 422 without a name", %{conn: conn} do
+      conn = post(conn, "/api/v1/workspaces", %{})
+
+      assert %{"errors" => %{"name" => ["can't be blank"]}} = json_response(conn, 422)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds GitBeholder.Repositories.list_workspaces/0
- Adds GET /api/v1/workspaces and POST /api/v1/workspaces
- Adds POST /api/v1/workspaces/:workspace_id/folders
- Adds POST /api/v1/workspaces/:workspace_id/repositories
- Adds GitBeholderWeb.ChangesetJSON to render changeset validation errors as 422 responses

Until now, Workspaces/Folders/Repositories could only be created through GitBeholder.Repositories directly (tests/IEx) - nothing on the HTTP surface could register them. This closes that gap, building on the model from ADR 005 and the FetchRepository plug from ADR 007.

## Test plan
- [x] mix test - 49 tests, 0 failures
- [x] Controller tests cover create success, validation errors (422), nested folder placement, and repository placement inside a folder