### PR TITLE
Keep GitBeholder bound to localhost only

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -15,7 +15,10 @@ config :git_beholder, GitBeholderWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
   http: [ip: {127, 0, 0, 1}, port: 4000],
-  check_origin: false,
+  # check_origin defaults to true, rejecting requests whose Origin header
+  # doesn't match this endpoint's host — GitBeholder is a local, single-user
+  # companion process (ADR 001) and is never meant to be reachable by
+  # arbitrary web pages open in the developer's browser.
   code_reloader: true,
   debug_errors: true,
   secret_key_base: "Yxd6Vt1TCo8SrHjljDhn+C+rD/M7P984hBLA1cOL1cxCy6KyEwYX32lQpBflm6nN",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -39,19 +39,17 @@ if config_env() == :prod do
       You can generate one by calling: mix phx.gen.secret
       """
 
-  host = System.get_env("PHX_HOST") || "example.com"
   port = String.to_integer(System.get_env("PORT") || "4000")
 
   config :git_beholder, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 
   config :git_beholder, GitBeholderWeb.Endpoint,
-    url: [host: host, port: 443, scheme: "https"],
+    url: [host: "localhost"],
+    # GitBeholder is a local, single-user companion process (ADR 001), not a
+    # publicly deployed web service — bind loopback-only so it's never
+    # reachable from the network, matching the dev environment's binding.
     http: [
-      # Enable IPv6 and bind on all interfaces.
-      # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
-      # See the documentation on https://hexdocs.pm/bandit/Bandit.html#t:options/0
-      # for details about using IPv6 vs IPv4 and loopback vs public addresses.
-      ip: {0, 0, 0, 0, 0, 0, 0, 0},
+      ip: {127, 0, 0, 1},
       port: port
     ],
     secret_key_base: secret_key_base


### PR DESCRIPTION
## Summary
- Removes check_origin: false in dev config (default true rejects requests whose Origin header doesn't match this endpoint's host)
- Rebinds the prod endpoint to 127.0.0.1 instead of 0.0.0.0, dropping the public-web host/scheme/port-443 defaults left over from the Phoenix generator

GitBeholder is a local, single-user companion process (ADR 001), not a networked service. Before this fix, any web page open in the developer's browser could reach the API over check_origin: false, and a release would bind on all network interfaces by default instead of loopback only.

## Test plan
- [x] mix test - 49 tests, 0 failures