### PR TITLE
refactor(app): semantic color-token system

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -35,6 +35,7 @@
   --color-overlay-hover: rgba(255, 255, 255, 0.03);
   --color-shadow-ambient: rgba(0, 0, 0, 0.35);
 
+  color-scheme: dark;
   color: var(--color-text-primary);
   background-color: var(--color-bg-canvas);
   font-family:
@@ -42,6 +43,48 @@
     system-ui,
     sans-serif;
   font-size: 13px;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    /* backgrounds */
+    --color-bg-canvas: #f6f8fb;
+    --color-bg-panel: #ffffff;
+    --color-bg-surface: #eef1f5;
+    --color-bg-surface-hover: #e2e6ec;
+    --color-bg-header-start: #ffffff;
+    --color-bg-header-end: #f3f5f8;
+
+    /* borders */
+    --color-border-subtle: rgba(15, 23, 42, 0.06);
+    --color-border-default: rgba(15, 23, 42, 0.12);
+
+    /* text */
+    --color-text-primary: #1a2028;
+    --color-text-secondary: #5b6572;
+    --color-text-faint: #8b93a1;
+    --color-text-on-accent: #ffffff;
+
+    /* accent (interactive / brand) */
+    --color-accent: #2f6fed;
+    --color-accent-soft: rgba(47, 111, 237, 0.12);
+    --color-accent-gradient-start: #4c8bf5;
+    --color-accent-gradient-end: #2f6fed;
+    --color-accent-glow: rgba(47, 111, 237, 0.25);
+    --color-brand-gradient-start: #2f6fed;
+    --color-brand-gradient-end: #9b6bff;
+    --color-brand-glow: rgba(47, 111, 237, 0.25);
+
+    /* status */
+    --color-success: #1a7f37;
+    --color-danger: #cf222e;
+
+    /* overlays */
+    --color-overlay-hover: rgba(15, 23, 42, 0.04);
+    --color-shadow-ambient: rgba(15, 23, 42, 0.12);
+
+    color-scheme: light;
+  }
 }
 
 * {

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -1,19 +1,42 @@
 :root {
-  --bg: #0b0e14;
-  --panel: #0f131b;
-  --surface: #141922;
-  --surface2: #1b212c;
-  --line: rgba(255, 255, 255, 0.07);
-  --line2: rgba(255, 255, 255, 0.12);
-  --text: #e8ecf3;
-  --muted: #9aa4b2;
-  --faint: #5f6a78;
-  --blue: #5b9dff;
-  --green: #3fb950;
-  --red: #f85149;
+  /* backgrounds */
+  --color-bg-canvas: #0b0e14;
+  --color-bg-panel: #0f131b;
+  --color-bg-surface: #141922;
+  --color-bg-surface-hover: #1b212c;
+  --color-bg-header-start: #10151e;
+  --color-bg-header-end: #0d1119;
 
-  color: var(--text);
-  background-color: var(--bg);
+  /* borders */
+  --color-border-subtle: rgba(255, 255, 255, 0.07);
+  --color-border-default: rgba(255, 255, 255, 0.12);
+
+  /* text */
+  --color-text-primary: #e8ecf3;
+  --color-text-secondary: #9aa4b2;
+  --color-text-faint: #5f6a78;
+  --color-text-on-accent: #0b0e14;
+
+  /* accent (interactive / brand) */
+  --color-accent: #5b9dff;
+  --color-accent-soft: rgba(91, 157, 255, 0.14);
+  --color-accent-gradient-start: #6ba6ff;
+  --color-accent-gradient-end: #4c8bf5;
+  --color-accent-glow: rgba(76, 139, 245, 0.35);
+  --color-brand-gradient-start: #5b9dff;
+  --color-brand-gradient-end: #bc8cff;
+  --color-brand-glow: rgba(91, 157, 255, 0.35);
+
+  /* status */
+  --color-success: #3fb950;
+  --color-danger: #f85149;
+
+  /* overlays */
+  --color-overlay-hover: rgba(255, 255, 255, 0.03);
+  --color-shadow-ambient: rgba(0, 0, 0, 0.35);
+
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-canvas);
   font-family:
     "IBM Plex Sans",
     system-ui,
@@ -37,7 +60,7 @@ body,
   display: flex;
   flex-direction: column;
   height: 100vh;
-  background: var(--bg);
+  background: var(--color-bg-canvas);
 }
 
 .app-body {
@@ -49,8 +72,8 @@ body,
 .app-sidebar {
   width: 240px;
   flex: 0 0 240px;
-  background: var(--panel);
-  border-right: 1px solid var(--line);
+  background: var(--color-bg-panel);
+  border-right: 1px solid var(--color-border-subtle);
   overflow-y: auto;
   padding: 12px 8px;
 }
@@ -70,7 +93,7 @@ body,
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--faint);
+  color: var(--color-text-faint);
   padding: 4px 8px;
 }
 
@@ -84,7 +107,7 @@ body,
   padding: 6px 9px;
   margin: 1px 0;
   font-size: 12.5px;
-  color: var(--text);
+  color: var(--color-text-primary);
   font-family: inherit;
   cursor: pointer;
   white-space: nowrap;
@@ -93,35 +116,35 @@ body,
 }
 
 .sidebar-item:hover {
-  background: var(--surface);
+  background: var(--color-bg-surface);
 }
 
 .sidebar-item--active {
-  background: rgba(91, 157, 255, 0.14);
-  color: var(--blue);
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
   font-weight: 600;
 }
 
 .sidebar-hint,
 .sidebar-error {
   font-size: 11.5px;
-  color: var(--faint);
+  color: var(--color-text-faint);
   padding: 4px 9px;
 }
 
 .sidebar-error {
-  color: var(--red);
+  color: var(--color-danger);
 }
 
 .empty-state {
   padding: 24px 16px;
-  color: var(--faint);
+  color: var(--color-text-faint);
   font-size: 12.5px;
   text-align: center;
 }
 
 .empty-state--error {
-  color: var(--red);
+  color: var(--color-danger);
 }
 
 .commit-log {
@@ -135,18 +158,18 @@ body,
   gap: 14px;
   height: 40px;
   padding: 0 16px;
-  border-bottom: 1px solid var(--line);
+  border-bottom: 1px solid var(--color-border-subtle);
 }
 
 .commit-row:hover {
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--color-overlay-hover);
 }
 
 .commit-row__hash {
   flex: 0 0 70px;
   font-family: "IBM Plex Mono", monospace;
   font-size: 11.5px;
-  color: var(--faint);
+  color: var(--color-text-faint);
 }
 
 .commit-row__message {
@@ -161,7 +184,7 @@ body,
 .commit-row__author {
   flex: 0 0 140px;
   font-size: 12px;
-  color: var(--muted);
+  color: var(--color-text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -171,6 +194,6 @@ body,
   flex: 0 0 96px;
   text-align: right;
   font-size: 11.5px;
-  color: var(--faint);
+  color: var(--color-text-faint);
   font-family: "IBM Plex Mono", monospace;
 }

--- a/app/src/components/Header.css
+++ b/app/src/components/Header.css
@@ -5,8 +5,8 @@
   align-items: center;
   gap: 16px;
   padding: 0 16px;
-  background: linear-gradient(180deg, #10151e, #0d1119);
-  border-bottom: 1px solid var(--line2);
+  background: linear-gradient(180deg, var(--color-bg-header-start), var(--color-bg-header-end));
+  border-bottom: 1px solid var(--color-border-default);
   position: relative;
   z-index: 20;
 }
@@ -25,11 +25,11 @@
   height: 34px;
   flex: 0 0 auto;
   border-radius: 9px;
-  background: linear-gradient(145deg, #5b9dff, #bc8cff);
+  background: linear-gradient(145deg, var(--color-brand-gradient-start), var(--color-brand-gradient-end));
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 4px 14px rgba(91, 157, 255, 0.35);
+  box-shadow: 0 4px 14px var(--color-brand-glow);
 }
 
 .app-header__repo-name {
@@ -44,7 +44,7 @@
 
 .app-header__repo-name--empty {
   font-weight: 400;
-  color: var(--faint);
+  color: var(--color-text-faint);
 }
 
 /* --- center: git actions --- */
@@ -55,11 +55,11 @@
   align-items: center;
   justify-content: center;
   gap: 2px;
-  background: var(--surface);
-  border: 1px solid var(--line2);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
   border-radius: 11px;
   padding: 5px;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 6px 20px var(--color-shadow-ambient);
   overflow-x: auto;
 }
 
@@ -75,7 +75,7 @@
   height: 34px;
   padding: 0 11px;
   background: transparent;
-  color: var(--text);
+  color: var(--color-text-primary);
   border: 1px solid transparent;
   border-radius: 8px;
   font-family: inherit;
@@ -87,25 +87,25 @@
 }
 
 .app-header__action:hover {
-  background: var(--surface2);
+  background: var(--color-bg-surface-hover);
 }
 
 .app-header__action--primary {
-  background: linear-gradient(180deg, #6ba6ff, #4c8bf5);
-  color: #0b0e14;
+  background: linear-gradient(180deg, var(--color-accent-gradient-start), var(--color-accent-gradient-end));
+  color: var(--color-text-on-accent);
   font-weight: 600;
-  box-shadow: 0 3px 10px rgba(76, 139, 245, 0.35);
+  box-shadow: 0 3px 10px var(--color-accent-glow);
 }
 
 .app-header__action--primary:hover {
   filter: brightness(1.08);
-  background: linear-gradient(180deg, #6ba6ff, #4c8bf5);
+  background: linear-gradient(180deg, var(--color-accent-gradient-start), var(--color-accent-gradient-end));
 }
 
 .app-header__divider {
   width: 1px;
   height: 22px;
-  background: var(--line2);
+  background: var(--color-border-default);
   margin: 0 4px;
 }
 
@@ -123,12 +123,12 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  background: var(--surface);
-  border: 1px solid var(--line);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-subtle);
   border-radius: 9px;
   padding: 7px 10px;
   width: 180px;
-  color: var(--faint);
+  color: var(--color-text-faint);
   font-size: 12px;
 }
 
@@ -136,8 +136,8 @@
   margin-left: auto;
   font-family: "IBM Plex Mono", monospace;
   font-size: 10px;
-  color: var(--faint);
-  border: 1px solid var(--line2);
+  color: var(--color-text-faint);
+  border: 1px solid var(--color-border-default);
   border-radius: 4px;
   padding: 0 4px;
 }
@@ -147,16 +147,16 @@
   height: 36px;
   flex: 0 0 auto;
   border-radius: 9px;
-  background: var(--surface);
-  border: 1px solid var(--line);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-subtle);
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  color: var(--muted);
+  color: var(--color-text-secondary);
 }
 
 .app-header__icon-button:hover {
-  background: var(--surface2);
-  color: var(--text);
+  background: var(--color-bg-surface-hover);
+  color: var(--color-text-primary);
 }

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -37,7 +37,7 @@ export function Header({ workspaceName, repositoryName }: HeaderProps) {
     <header className="app-header">
       <div className="app-header__repo">
         <div className="app-header__logo">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#0b0e14" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--color-text-on-accent)" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
             <circle cx="6" cy="6" r="2.4" />
             <circle cx="6" cy="18" r="2.4" />
             <circle cx="18" cy="9" r="2.4" />
@@ -47,7 +47,7 @@ export function Header({ workspaceName, repositoryName }: HeaderProps) {
         {repositoryName ? (
           <span className="app-header__repo-name">
             {workspaceName} / {repositoryName}
-            <Icon name="chevronDown" size={13} color="var(--faint)" />
+            <Icon name="chevronDown" size={13} color="var(--color-text-faint)" />
           </span>
         ) : (
           <span className="app-header__repo-name app-header__repo-name--empty">
@@ -66,9 +66,9 @@ export function Header({ workspaceName, repositoryName }: HeaderProps) {
                 "app-header__action" + (action.primary ? " app-header__action--primary" : "")
               }
             >
-              <Icon name={action.icon} color={action.primary ? "#0b0e14" : "currentColor"} />
+              <Icon name={action.icon} color={action.primary ? "var(--color-text-on-accent)" : "currentColor"} />
               <span>{action.label}</span>
-              {action.caret && <Icon name="chevronDown" size={11} color="var(--faint)" />}
+              {action.caret && <Icon name="chevronDown" size={11} color="var(--color-text-faint)" />}
             </button>
             {action.dividerAfter && <span className="app-header__divider" />}
           </span>
@@ -77,7 +77,7 @@ export function Header({ workspaceName, repositoryName }: HeaderProps) {
 
       <div className="app-header__utilities">
         <div className="app-header__search">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--faint)" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--color-text-faint)" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
             <circle cx="11" cy="11" r="7" />
             <path d="M20 20l-3.5-3.5" />
           </svg>


### PR DESCRIPTION
## Summary
- Rename the CSS custom properties in `App.css` from literal names (`--blue`, `--line2`, `--surface2`) to semantic, role-based tokens (`--color-accent`, `--color-border-default`, `--color-bg-surface-hover`, etc.)
- Add tokens for values that only ever existed as inline hex (header gradient, primary button gradient/glow, on-accent text, brand glow)
- Replace every remaining hardcoded hex in `Header.tsx`/`Header.css` with the new tokens, so all color values live in one place

## Test plan
- [ ] `cd app && pnpm tsc --noEmit` passes
- [ ] Header and sidebar render with unchanged colors (values are 1:1 renames, no visual change expected)