### PR TITLE
Toasts for Azure DevOps integration errors

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -23,6 +23,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "shadcn": "^4.13.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       shadcn:
         specifier: ^4.13.0
         version: 4.13.0(typescript@5.8.3)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -2241,6 +2244,12 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4533,6 +4542,11 @@ snapshots:
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
+
+  sonner@2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   source-map-js@1.2.1: {}
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,11 +1,13 @@
 import { SessionProvider } from "./features/session";
 import { AppShell } from "./layout/AppShell";
+import { Toaster } from "./components/ui/sonner";
 import "./App.css";
 
 function App() {
   return (
     <SessionProvider>
       <AppShell />
+      <Toaster />
     </SessionProvider>
   );
 }

--- a/app/src/components/ui/sonner.tsx
+++ b/app/src/components/ui/sonner.tsx
@@ -1,0 +1,44 @@
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  return (
+    <Sonner
+      theme="system"
+      className="toaster group"
+      icons={{
+        success: (
+          <CircleCheckIcon className="size-4" />
+        ),
+        info: (
+          <InfoIcon className="size-4" />
+        ),
+        warning: (
+          <TriangleAlertIcon className="size-4" />
+        ),
+        error: (
+          <OctagonXIcon className="size-4" />
+        ),
+        loading: (
+          <Loader2Icon className="size-4 animate-spin" />
+        ),
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/app/src/layout/columns/ConnectAzureDevOpsDialog.tsx
+++ b/app/src/layout/columns/ConnectAzureDevOpsDialog.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -26,7 +27,6 @@ export function ConnectAzureDevOpsDialog({
   const [isTesting, setIsTesting] = React.useState(false)
   const [isSaving, setIsSaving] = React.useState(false)
   const [testPassed, setTestPassed] = React.useState(false)
-  const [error, setError] = React.useState<string | null>(null)
 
   const testConnection = useTestAzureDevOpsConnection()
   const connect = useConnectAzureDevOps()
@@ -37,7 +37,6 @@ export function ConnectAzureDevOpsDialog({
       setProject("")
       setPat("")
       setTestPassed(false)
-      setError(null)
     }
   }, [open])
 
@@ -52,13 +51,12 @@ export function ConnectAzureDevOpsDialog({
 
   const handleTest = async () => {
     setIsTesting(true)
-    setError(null)
     try {
       await testConnection({ config: { org_url: orgUrl.trim(), project: project.trim() }, credentials: pat })
       setTestPassed(true)
     } catch (err) {
       setTestPassed(false)
-      setError(String(err))
+      toast.error(String(err))
     } finally {
       setIsTesting(false)
     }
@@ -66,12 +64,11 @@ export function ConnectAzureDevOpsDialog({
 
   const handleSave = async () => {
     setIsSaving(true)
-    setError(null)
     try {
       await connect({ config: { org_url: orgUrl.trim(), project: project.trim() }, credentials: pat })
       onOpenChange(false)
     } catch (err) {
-      setError(String(err))
+      toast.error(String(err))
     } finally {
       setIsSaving(false)
     }
@@ -124,7 +121,6 @@ export function ConnectAzureDevOpsDialog({
             onChange={(e) => updateField(setPat)(e.target.value)}
             disabled={isBusy}
           />
-          {error && <p className="text-caption text-danger">{error}</p>}
         </div>
 
         <DialogFooter showCloseButton>

--- a/app/src/layout/columns/RepositoryOverviewColumn.tsx
+++ b/app/src/layout/columns/RepositoryOverviewColumn.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { toast } from "sonner"
 import {
   Archive,
   CircleCheck,
@@ -169,16 +170,14 @@ export function RepositoryOverviewColumn() {
   const disconnectAzureDevOps = useDisconnectAzureDevOps()
   const [isAzureDialogOpen, setIsAzureDialogOpen] = useState(false)
   const [isDisconnecting, setIsDisconnecting] = useState(false)
-  const [integrationError, setIntegrationError] = useState<string | null>(null)
   const otherIntegrations = INTEGRATIONS.filter(({ name }) => name !== "Azure DevOps")
 
   const handleDisconnectAzureDevOps = async () => {
     setIsDisconnecting(true)
-    setIntegrationError(null)
     try {
       await disconnectAzureDevOps()
     } catch (err) {
-      setIntegrationError(String(err))
+      toast.error(String(err))
     } finally {
       setIsDisconnecting(false)
     }
@@ -410,12 +409,6 @@ export function RepositoryOverviewColumn() {
       {checkoutError && (
         <div className="border-t border-line-subtle px-panel-x py-2 text-caption text-danger">
           {checkoutError}
-        </div>
-      )}
-
-      {integrationError && (
-        <div className="border-t border-line-subtle px-panel-x py-2 text-caption text-danger">
-          {integrationError}
         </div>
       )}
 

--- a/docs/azure-devops-integration.md
+++ b/docs/azure-devops-integration.md
@@ -1,0 +1,129 @@
+# Integração com Azure DevOps
+
+Documenta o que foi implementado das issues [#48](https://github.com/elyosemite/GitBeholder/issues/48)
+(backend, fechada) e [#49](https://github.com/elyosemite/GitBeholder/issues/49)
+(frontend), parte do epic [#47](https://github.com/elyosemite/GitBeholder/issues/47).
+A proposta original/domain model completo está em
+`docs/proposals/work-item-integrations.md` — este documento cobre só o que
+existe hoje no código, não o escopo futuro (busca de work items, badge no
+commit, auto-close no merge, outros providers).
+
+## O que existe
+
+Uma Repository pode ser conectada a uma organização/projeto do Azure DevOps
+via Personal Access Token (PAT). A conexão é testável antes de salvar,
+consultável e desconectável — tudo pela seção **Integrations** do
+`RepositoryOverviewColumn`, sem tela de settings dedicada (decisão explícita:
+o dono do repo pediu para ficar ali mesmo, em vez de criar uma navegação
+nova).
+
+## Backend (issue #48)
+
+- `integrations` (migration): `repository_id`, `provider`, `config` (map:
+  `org_url`, `project`), `credentials` (binário criptografado via
+  `Plug.Crypto` — nunca sai em texto puro), `enabled`,
+  `auto_close_enabled` (default `false`), `auto_close_target_state`
+  (nullable). Os campos de auto-close existem no schema mas não têm UI
+  ainda (ver "Deixado de fora").
+- `GitBeholder.Integrations` (contexto): `connect/2`, `test_connection/1`
+  (não persiste), `get_connection/1`, `disconnect/1`.
+- `GitBeholder.Integrations.WorkItemProvider` (behaviour): contrato comum
+  para providers futuros (`list_types/1`, `search_items/2`, `get_item/2`,
+  `transition_item/3`, `link_commit/3`) — só `list_types/1` é usado hoje.
+- `GitBeholder.Integrations.AzureDevOps`: implementa `list_types/1` contra
+  `GET _apis/wit/workitemtypes` via `Finch`. Mapeia falhas para
+  `{:error, :invalid_token}` / `{:error, :connection_failed}` /
+  `{:error, :not_found}` / `{:error, :invalid_response}`.
+- Testado via `Mox` em `test/git_beholder/integrations/azure_devops_test.exs`
+  (PAT válido, inválido/expirado, org inalcançável).
+
+### Rotas
+
+```
+POST   /api/v1/workspaces/:workspace_id/repositories/:repository_id/integrations/azure-devops
+POST   /api/v1/workspaces/:workspace_id/repositories/:repository_id/integrations/azure-devops/test
+GET    /api/v1/workspaces/:workspace_id/repositories/:repository_id/integrations/azure-devops
+DELETE /api/v1/workspaces/:workspace_id/repositories/:repository_id/integrations/azure-devops
+```
+
+Documentadas na collection Postman **GitBeholder** (workspace **Open
+Source**), pasta *Azure DevOps* — nenhuma rota nova foi criada pelo trabalho
+do frontend, então a collection não precisou de atualização.
+
+## Frontend (issue #49)
+
+### `features/integrations/`
+
+Segue o mesmo formato de toda feature do app (`api.ts` / `types.ts` /
+`hooks/` / `index.ts` — ver `docs/frontend-architecture.md`):
+
+- `types.ts`: `AzureDevOpsConfig`, `Integration`, `ConnectAzureDevOpsPayload`.
+- `api.ts`: `getAzureDevOpsIntegration` (um 404 vira `null` — "não
+  conectado" é estado normal, não erro), `testAzureDevOpsConnection`,
+  `connectAzureDevOps`, `disconnectAzureDevOps`.
+- `hooks/useAzureDevOpsIntegration.ts`: hook de leitura, mesmo padrão de
+  `useBranches` — `useApiData` chaveado em
+  `[repository?.id, revisions.integrations]`.
+- `hooks/useConnectAzureDevOps.ts`, `useTestAzureDevOpsConnection.ts`,
+  `useDisconnectAzureDevOps.ts`: hooks de mutação; connect/disconnect
+  chamam `invalidate("integrations")` ao final, test não (não persiste
+  nada).
+
+### Mudanças em código compartilhado
+
+- `features/session/types.ts` e `revisions.ts`: novo escopo
+  `"integrations"` em `DataScope`/`initialRevisions`.
+- `lib/api-client.ts`: `request()` agora trata `204 No Content` (resolve
+  `undefined` em vez de chamar `.json()`, que quebraria em corpo vazio) —
+  necessário porque `disconnect` foi o primeiro endpoint do app a
+  responder 204.
+
+### `ConnectAzureDevOpsDialog`
+
+`app/src/layout/columns/ConnectAzureDevOpsDialog.tsx`. Mesmo padrão de
+`CloneRepositoryDialog`: `{ open, onOpenChange }` controlado, estado local
+(`useState`) por campo, erro inline (`text-caption text-danger`), sem
+biblioteca de toast (o app não usa nenhuma — ver decisão abaixo).
+
+Campos: Organization URL, Project, Personal access token (`type="password"`,
+mascarado). O botão **Save** só destrava depois de **Test connection**
+suceder; editar qualquer campo depois de um teste bem-sucedido re-trava o
+Save (as credenciais salvas precisam ser as mesmas testadas).
+
+### `RepositoryOverviewColumn`
+
+A linha "Azure DevOps" dentro da seção **Integrations** deixou de ser mock:
+usa `useAzureDevOpsIntegration()` para saber se está conectado, mostra
+`PlatformIcon platform="azure-devops"` em vez do avatar de iniciais, e um
+botão **Connect…** (abre o dialog) ou **Disconnect** conforme o estado. As
+outras linhas da seção (GitHub, Jira etc.) continuam mockadas — só a Azure
+DevOps foi implementada, por ser a única com backend real.
+
+## Decisões e coisas deixadas de fora
+
+- **Sem toggle de auto-close nesta v1.** A issue #49 não pede isso
+  explicitamente (só a #47, o epic, menciona); o backend já aceita
+  `auto_close_enabled`/`auto_close_target_state`, então expor isso depois é
+  aditivo, não retrabalho.
+- **Erros inline, não toast.** A issue #49 fala em "toasts", mas o app não
+  tem nenhuma biblioteca de toast instalada — todo erro em todo lugar do
+  app é inline (`CloneRepositoryDialog`, o rodapé de erro do checkout de
+  branch, etc.). Introduzir uma dependência nova só para este fluxo quebraria
+  essa convenção; os erros de connect/test/disconnect aparecem como parágrafo
+  inline, do mesmo jeito.
+- **Sem tela de settings dedicada.** A issue #49 original imaginava uma
+  "primeira tela de settings do repositório"; a implementação ficou dentro
+  do `RepositoryOverviewColumn` existente, por instrução direta do
+  dono do repositório.
+- **Não verificado com `tsc --noEmit`** no commit que fez o wiring final
+  (`be2c645`) — Node.js estava indisponível no ambiente no momento. Rodar o
+  typecheck manualmente antes de considerar a issue #49 fechada.
+
+## Como testar manualmente
+
+1. Suba o backend (`mix phx.server`, feito manualmente) e o app.
+2. Selecione um repositório → seção **Integrations** → **Connect…**.
+3. Preencha Organization URL / Project / PAT → **Test connection**.
+4. Se o teste passar, **Save** destrava → salva a conexão.
+5. A linha deve virar "Connected" com ação **Disconnect**.
+6. **Disconnect** deve reverter a linha para "Connect…".

--- a/docs/azure-devops-integration.md
+++ b/docs/azure-devops-integration.md
@@ -105,19 +105,23 @@ DevOps foi implementada, por ser a única com backend real.
   explicitamente (só a #47, o epic, menciona); o backend já aceita
   `auto_close_enabled`/`auto_close_target_state`, então expor isso depois é
   aditivo, não retrabalho.
-- **Erros inline, não toast.** A issue #49 fala em "toasts", mas o app não
-  tem nenhuma biblioteca de toast instalada — todo erro em todo lugar do
-  app é inline (`CloneRepositoryDialog`, o rodapé de erro do checkout de
-  branch, etc.). Introduzir uma dependência nova só para este fluxo quebraria
-  essa convenção; os erros de connect/test/disconnect aparecem como parágrafo
-  inline, do mesmo jeito.
+- **Erros via toast (shadcn `sonner`), não mais inline.** A issue #49 pedia
+  toasts; a v1 tinha ficado inline porque o app não tinha nenhuma lib de
+  toast instalada. Resolvido instalando o componente `sonner` do registry
+  do shadcn (`pnpm dlx shadcn@latest add sonner`) — mesma fonte dos outros
+  componentes em `app/src/components/ui/`, então não quebra a convenção de
+  "sem lib de UI fora do shadcn". `<Toaster />` montado uma vez em
+  `App.tsx`; os erros de connect/test/disconnect chamam `toast.error(...)`.
+  O componente gerado vinha acoplado a `next-themes` (`useTheme()`) para
+  decidir light/dark, mas o app não tem `ThemeProvider` nenhum — troquei
+  por `theme="system"` fixo (o próprio `sonner` já resolve dark/light via
+  `prefers-color-scheme` nesse modo) e removi a dependência `next-themes`
+  do `package.json`, que tinha sido adicionada automaticamente pelo CLI do
+  shadcn e ficaria sem uso.
 - **Sem tela de settings dedicada.** A issue #49 original imaginava uma
   "primeira tela de settings do repositório"; a implementação ficou dentro
   do `RepositoryOverviewColumn` existente, por instrução direta do
   dono do repositório.
-- **Não verificado com `tsc --noEmit`** no commit que fez o wiring final
-  (`be2c645`) — Node.js estava indisponível no ambiente no momento. Rodar o
-  typecheck manualmente antes de considerar a issue #49 fechada.
 
 ## Como testar manualmente
 


### PR DESCRIPTION
## Summary

- Documents the Azure DevOps v1 implementation (`docs/azure-devops-integration.md`, was untracked on main).
- Installs shadcn's `sonner` toast component via pnpm, mounted once at the app root.
- Replaces inline error text on connect/test/disconnect (Azure DevOps integration) with `toast.error(...)`, closing the "toasts" acceptance criterion from #49 that had shipped as a documented deviation.

## Test plan

- [x] `tsc --noEmit` passes
- [ ] Manual: connect with a bad PAT/org and confirm the error surfaces as a toast, not inline text
- [ ] Manual: disconnect and confirm a forced failure (e.g. offline) surfaces as a toast

Refs #49